### PR TITLE
Added windows specific settings to VSCode

### DIFF
--- a/.settings/bundles-lock.store.json
+++ b/.settings/bundles-lock.store.json
@@ -84,6 +84,10 @@
       "selected_by": [
         {
           "name": "gnu-tools-for-stm32-14_3_1-description",
+          "version": "1.0.1+st.2"
+        },
+        {
+          "name": "gnu-tools-for-stm32-14_3_1-description",
           "version": ">=0.0.1"
         }
       ]

--- a/.settings/bundles.store.json
+++ b/.settings/bundles.store.json
@@ -15,6 +15,10 @@
     {
       "name": "st-arm-clangd",
       "version": "21.1.0+st.2"
+    },
+    {
+      "name": "gnu-tools-for-stm32-14_3_1-description",
+      "version": "1.0.1+st.2"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,17 +17,27 @@
             "interface": "swd",
             "serialNumber": "",
             "runToEntryPoint": "main",
-            "svdFile": "${config:STM32VSCodeExtension.cubeCLT.path}/STMicroelectronics_CMSIS_SVD/STM32F407.svd",
             "v1": false,
-            "serverpath": "${config:STM32VSCodeExtension.cubeCLT.path}/STLink-gdb-server/bin/ST-LINK_gdbserver",
-            "stm32cubeprogrammer": "${config:STM32VSCodeExtension.cubeCLT.path}/STM32CubeProgrammer/bin",
-            "stlinkPath": "${config:STM32VSCodeExtension.cubeCLT.path}/STLink-gdb-server/bin/ST-LINK_gdbserver",
-            "armToolchainPath": "${config:STM32VSCodeExtension.cubeCLT.path}/GNU-tools-for-STM32/bin",
-            "gdbPath": "${config:STM32VSCodeExtension.cubeCLT.path}/GNU-tools-for-STM32/bin/arm-none-eabi-gdb",
             "serverArgs": [
                 "-m",
                 "0"
             ],
+            "windows": {
+                "svdFile": "C:/ST/STM32CubeCLT_1.15.1/STMicroelectronics_CMSIS_SVD/STM32F407.svd",
+                "serverpath": "C:/ST/STM32CubeCLT_1.15.1/STLink-gdb-server/bin/ST-LINK_gdbserver",
+                "stm32cubeprogrammer": "C:/ST/STM32CubeCLT_1.15.1/STM32CubeProgrammer/bin",
+                "stlinkPath": "C:/ST/STM32CubeCLT_1.15.1/STLink-gdb-server/bin/ST-LINK_gdbserver",
+                "armToolchainPath": "C:/ST/STM32CubeCLT_1.15.1/GNU-tools-for-STM32/bin",
+                "gdbPath": "C:/ST/STM32CubeCLT_1.15.1/GNU-tools-for-STM32/bin/arm-none-eabi-gdb.exe"
+            },
+            "linux": {
+                "svdFile": "${config:STM32VSCodeExtension.cubeCLT.path}/STMicroelectronics_CMSIS_SVD/STM32F407.svd",
+                "serverpath": "${config:STM32VSCodeExtension.cubeCLT.path}/STLink-gdb-server/bin/ST-LINK_gdbserver",
+                "stm32cubeprogrammer": "${config:STM32VSCodeExtension.cubeCLT.path}/STM32CubeProgrammer/bin",
+                "stlinkPath": "${config:STM32VSCodeExtension.cubeCLT.path}/STLink-gdb-server/bin/ST-LINK_gdbserver",
+                "armToolchainPath": "${config:STM32VSCodeExtension.cubeCLT.path}/GNU-tools-for-STM32/bin",
+                "gdbPath": "${config:STM32VSCodeExtension.cubeCLT.path}/GNU-tools-for-STM32/bin/arm-none-eabi-gdb"
+            },
             "preLaunchTask": "Build project"
         },
         {
@@ -56,17 +66,27 @@
             "interface": "swd",
             "serialNumber": "",
             "runToEntryPoint": "main",
-            "svdFile": "${config:STM32VSCodeExtension.cubeCLT.path}/STMicroelectronics_CMSIS_SVD/STM32F407.svd",
             "v1": false,
-            "serverpath": "${config:STM32VSCodeExtension.cubeCLT.path}/STLink-gdb-server/bin/ST-LINK_gdbserver",
-            "stm32cubeprogrammer": "${config:STM32VSCodeExtension.cubeCLT.path}/STM32CubeProgrammer/bin",
-            "stlinkPath": "${config:STM32VSCodeExtension.cubeCLT.path}/STLink-gdb-server/bin/ST-LINK_gdbserver",
-            "armToolchainPath": "${config:STM32VSCodeExtension.cubeCLT.path}/GNU-tools-for-STM32/bin",
-            "gdbPath": "${config:STM32VSCodeExtension.cubeCLT.path}/GNU-tools-for-STM32/bin/arm-none-eabi-gdb",
             "serverArgs": [
                 "-m",
                 "0"
-            ]
+            ],
+            "windows": {
+                "svdFile": "C:/ST/STM32CubeCLT_1.15.1/STMicroelectronics_CMSIS_SVD/STM32F407.svd",
+                "serverpath": "C:/ST/STM32CubeCLT_1.15.1/STLink-gdb-server/bin/ST-LINK_gdbserver",
+                "stm32cubeprogrammer": "C:/ST/STM32CubeCLT_1.15.1/STM32CubeProgrammer/bin",
+                "stlinkPath": "C:/ST/STM32CubeCLT_1.15.1/STLink-gdb-server/bin/ST-LINK_gdbserver",
+                "armToolchainPath": "C:/ST/STM32CubeCLT_1.15.1/GNU-tools-for-STM32/bin",
+                "gdbPath": "C:/ST/STM32CubeCLT_1.15.1/GNU-tools-for-STM32/bin/arm-none-eabi-gdb.exe"
+            },
+            "linux": {
+                "svdFile": "${config:STM32VSCodeExtension.cubeCLT.path}/STMicroelectronics_CMSIS_SVD/STM32F407.svd",
+                "serverpath": "${config:STM32VSCodeExtension.cubeCLT.path}/STLink-gdb-server/bin/ST-LINK_gdbserver",
+                "stm32cubeprogrammer": "${config:STM32VSCodeExtension.cubeCLT.path}/STM32CubeProgrammer/bin",
+                "stlinkPath": "${config:STM32VSCodeExtension.cubeCLT.path}/STLink-gdb-server/bin/ST-LINK_gdbserver",
+                "armToolchainPath": "${config:STM32VSCodeExtension.cubeCLT.path}/GNU-tools-for-STM32/bin",
+                "gdbPath": "${config:STM32VSCodeExtension.cubeCLT.path}/GNU-tools-for-STM32/bin/arm-none-eabi-gdb"
+            }
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -72,7 +72,7 @@
     ],
     "cmake.cmakePath": "cube-cmake",
     "cmake.configureArgs": [
-        "-DCMAKE_COMMAND=cube-cmake",
+        "-DCMAKE_COMMAND=cube-cmake"
     ],
     "STM32VSCodeExtension.cubeCLT.path": "/opt/st/stm32cubeclt_1.20.0",
     "stm32cube-ide-clangd.path": "cube",
@@ -81,4 +81,7 @@
         "--query-driver=${env:CUBE_BUNDLE_PATH}/gnu-tools-for-stm32/14.3.1+st.2/bin/arm-none-eabi-gcc*",
         "--query-driver=${env:CUBE_BUNDLE_PATH}/gnu-tools-for-stm32/14.3.1+st.2/bin/arm-none-eabi-g++*"
     ],
+    "[windows]": {
+        "STM32VSCodeExtension.cubeCLT.path": "C:/ST/STM32CubeCLT_1.15.1"
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -74,14 +74,10 @@
     "cmake.configureArgs": [
         "-DCMAKE_COMMAND=cube-cmake"
     ],
-    "STM32VSCodeExtension.cubeCLT.path": "/opt/st/stm32cubeclt_1.20.0",
     "stm32cube-ide-clangd.path": "cube",
     "stm32cube-ide-clangd.arguments": [
         "starm-clangd",
         "--query-driver=${env:CUBE_BUNDLE_PATH}/gnu-tools-for-stm32/14.3.1+st.2/bin/arm-none-eabi-gcc*",
         "--query-driver=${env:CUBE_BUNDLE_PATH}/gnu-tools-for-stm32/14.3.1+st.2/bin/arm-none-eabi-g++*"
     ],
-    "[windows]": {
-        "STM32VSCodeExtension.cubeCLT.path": "C:/ST/STM32CubeCLT_1.15.1"
-    }
 }


### PR DESCRIPTION
# Summary

Small patch to add windows specific settings field to VSCode for cube-clt path. 

Users may update the path to point to their own version of ST cube CLT tools