### PR TITLE
63 Redirect unity output to USB serial COM port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
 # Add project symbols (macros)
 target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE
     # Add user defined symbols
+    UNITY_INCLUDE_CONFIG_H
 )
 
 # Add linked libraries

--- a/Core/Inc/FreeRTOSConfig.h
+++ b/Core/Inc/FreeRTOSConfig.h
@@ -68,7 +68,7 @@
 #define configTICK_RATE_HZ                       ((TickType_t)1000)
 #define configMAX_PRIORITIES                     ( 56 )
 #define configMINIMAL_STACK_SIZE                 ((uint16_t)128)
-#define configTOTAL_HEAP_SIZE                    ((size_t)15360)
+#define configTOTAL_HEAP_SIZE                    ((size_t)32768)
 #define configMAX_TASK_NAME_LEN                  ( 16 )
 #define configUSE_TRACE_FACILITY                 1
 #define configUSE_16_BIT_TICKS                   0

--- a/Core/Tests/hardware/unity_config.h
+++ b/Core/Tests/hardware/unity_config.h
@@ -1,0 +1,3 @@
+#pragma once
+#include "log.h"
+#define UNITY_OUTPUT_CHAR(a) log_putchar(a)

--- a/Core/User/log.c
+++ b/Core/User/log.c
@@ -5,6 +5,7 @@
 #include "usbd_cdc_if.h"
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -16,8 +17,52 @@
 // Helper functions
 // ---------------------------------------------------------------------------
 
-static bool s_log_initialized = false;
+static bool               s_log_initialized = false;
 static osMessageQueueId_t s_log_queue;
+
+// ---------------------------------------------------------------------------
+// log_putchar 
+// Used for line-buffered char sink (i.e. Unity)
+// ---------------------------------------------------------------------------
+
+#define LOG_PUTCHAR_LINE_LEN 128U
+#define LOG_PUTCHAR_MAX_LINES 16U
+
+static char    s_line_buf[LOG_PUTCHAR_LINE_LEN];
+static uint8_t s_line_len = 0U;
+
+// ---------------------------------------------------------------------------
+// This is a simple way to capture early logs without dynamic memory allocation 
+// or complex buffering logic. Used for tracking logs generated before log_init() 
+// ---------------------------------------------------------------------------
+static char    s_pre_init_lines[LOG_PUTCHAR_MAX_LINES][LOG_PUTCHAR_LINE_LEN];
+static uint8_t s_pre_init_line_count = 0U;
+
+static void putchar_flush_line(void) {
+    if (s_line_len == 0U) {
+        return;
+    }
+    s_line_buf[s_line_len] = '\0';
+
+    if (s_log_initialized) {
+        log_printf("%s\r\n", s_line_buf);
+    } else if (s_pre_init_line_count < LOG_PUTCHAR_MAX_LINES) {
+        memcpy(s_pre_init_lines[s_pre_init_line_count], s_line_buf, s_line_len + 1U);
+        s_pre_init_line_count++;
+    }
+
+    s_line_len = 0U;
+}
+
+void log_putchar(int c) {
+    if (c == '\n') {
+        putchar_flush_line();
+    } else if (c != '\r') {
+        if (s_line_len < LOG_PUTCHAR_LINE_LEN - 1U) {
+            s_line_buf[s_line_len++] = (char)c;
+        }
+    }
+}
 
 // Writes a log message to the USB CDC queue.
 static bool log_usb_write(const char *buf, size_t len) {
@@ -202,6 +247,12 @@ bool log_init(void) {
         return false;
     }
     s_log_initialized = true;
+
+    for (uint8_t i = 0; i < s_pre_init_line_count; i++) {
+        log_printf("%s\r\n", s_pre_init_lines[i]);
+    }
+    s_pre_init_line_count = 0U;
+
     return true;
 }
 

--- a/Core/User/log.c
+++ b/Core/User/log.c
@@ -16,12 +16,10 @@
 // Helper functions
 // ---------------------------------------------------------------------------
 
-static bool               s_log_initialized = false;
-static uint8_t            s_usb_tx_buffer[UART_BUF_SIZE];
+static bool s_log_initialized = false;
 static osMessageQueueId_t s_log_queue;
 
-
-// Writes a log message to the USB CDC queue. 
+// Writes a log message to the USB CDC queue.
 static bool log_usb_write(const char *buf, size_t len) {
     if (!s_log_initialized) {
         return false;
@@ -37,7 +35,6 @@ static bool log_usb_write(const char *buf, size_t len) {
     msg.len = len;
 
     return (osMessageQueuePut(s_log_queue, &msg, 0, 0) == osOK);
-
 }
 
 static uint32_t log_get_time_ms(void) {
@@ -209,7 +206,7 @@ bool log_init(void) {
 }
 
 bool log_write(const LogEvent_t *event) {
-    if ((event == NULL) || !s_log_initialized) {
+    if ((event == NULL) || !s_log_initialized || (event->level < LOG_MIN_LEVEL)) {
         return false;
     }
 
@@ -247,18 +244,17 @@ void log_printf(const char *format, ...) {
 
 void log_usb_task(void *argument) {
     LogMsg_t msg;
-    for (;;) { 
+    for (;;) {
         if (osMessageQueueGet(s_log_queue, &msg, NULL, osWaitForever) == osOK) {
             // Wait until USB is free
-            while (CDC_Transmit_FS((uint8_t*)msg.data, msg.len) == USBD_BUSY) {
+            while (CDC_Transmit_FS((uint8_t *)msg.data, msg.len) == USBD_BUSY) {
                 osDelay(1);
             }
 
             // Wait until TX complete
-            while (CDC_IsTxBusy())
-            {
+            while (CDC_IsTxBusy()) {
                 osDelay(1);
             }
         }
     }
-}    
+}

--- a/Core/User/log.c
+++ b/Core/User/log.c
@@ -25,7 +25,7 @@ static osMessageQueueId_t s_log_queue;
 // ---------------------------------------------------------------------------
 
 #define LOG_PUTCHAR_LINE_LEN 128U
-#define LOG_PUTCHAR_MAX_LINES 16U
+#define LOG_PUTCHAR_MAX_LINES 64U
 
 static char    s_line_buf[LOG_PUTCHAR_LINE_LEN];
 static uint8_t s_line_len = 0U;
@@ -241,8 +241,8 @@ static void sink_uart_printf(const char *buf, size_t len) {
 // ---------------------------------------------------------------------------
 
 bool log_init(void) {
-    const int msg_count = 8;
-    s_log_queue = osMessageQueueNew(msg_count, sizeof(LogMsg_t), NULL);
+    const int pre_boot_msg_count = 24; // warning: large values will consume RAM due to static allocation
+    s_log_queue = osMessageQueueNew(pre_boot_msg_count, sizeof(LogMsg_t), NULL);
     if (s_log_queue == NULL) {
         return false;
     }
@@ -294,6 +294,8 @@ void log_printf(const char *format, ...) {
 }
 
 void log_usb_task(void *argument) {
+    (void)argument;
+    osDelay(1000); // wait for USB host enumeration before transmitting
     LogMsg_t msg;
     for (;;) {
         if (osMessageQueueGet(s_log_queue, &msg, NULL, osWaitForever) == osOK) {

--- a/Core/User/log.c
+++ b/Core/User/log.c
@@ -21,8 +21,7 @@ static bool               s_log_initialized = false;
 static osMessageQueueId_t s_log_queue;
 
 // ---------------------------------------------------------------------------
-// log_putchar 
-// Used for line-buffered char sink (i.e. Unity)
+// log_putchar
 // ---------------------------------------------------------------------------
 
 #define LOG_PUTCHAR_LINE_LEN 128U
@@ -31,13 +30,13 @@ static osMessageQueueId_t s_log_queue;
 static char    s_line_buf[LOG_PUTCHAR_LINE_LEN];
 static uint8_t s_line_len = 0U;
 
-// ---------------------------------------------------------------------------
 // This is a simple way to capture early logs without dynamic memory allocation 
 // or complex buffering logic. Used for tracking logs generated before log_init() 
-// ---------------------------------------------------------------------------
 static char    s_pre_init_lines[LOG_PUTCHAR_MAX_LINES][LOG_PUTCHAR_LINE_LEN];
 static uint8_t s_pre_init_line_count = 0U;
 
+// Flushes the current line buffer to the appropriate sink 
+// (USB if initialized, otherwise pre-init buffer).
 static void putchar_flush_line(void) {
     if (s_line_len == 0U) {
         return;
@@ -54,6 +53,7 @@ static void putchar_flush_line(void) {
     s_line_len = 0U;
 }
 
+// Used for line-buffered char sink (i.e. Unity)
 void log_putchar(int c) {
     if (c == '\n') {
         putchar_flush_line();

--- a/Core/User/log.h
+++ b/Core/User/log.h
@@ -20,7 +20,7 @@ typedef enum {
 } LogLevel_t;
 
 // Only events at or above this level are printed to serial.
-#define LOG_MIN_LEVEL LOG_LEVEL_WARN
+#define LOG_MIN_LEVEL LOG_LEVEL_INFO
 
 // List of possible firmware events
 typedef enum {

--- a/Core/User/log.h
+++ b/Core/User/log.h
@@ -19,6 +19,9 @@ typedef enum {
     LOG_LEVEL_ERROR
 } LogLevel_t;
 
+// Only events at or above this level are printed to serial.
+#define LOG_MIN_LEVEL LOG_LEVEL_WARN
+
 // List of possible firmware events
 typedef enum {
     EVT_BOOT = 0u,

--- a/Core/User/log.h
+++ b/Core/User/log.h
@@ -81,6 +81,10 @@ bool log_write(const LogEvent_t *event);
 // Optional plain-text printf-style interface for debug output
 void log_printf(const char *format, ...);
 
+// Char-at-a-time sink — buffers into lines and forwards to log_printf.
+// Safe to call before log_init(); pre-init output is flushed when log_init() runs.
+void log_putchar(int c);
+
 // Convenience macro — requires LOG_MODULE to be defined before including this header.
 // Falls back to LOG_SRC_UNKNOWN if LOG_MODULE is not defined.
 #ifndef LOG_MODULE


### PR DESCRIPTION
# Summary

Closes #63 

## Log Output 

```
---- Reopened serial port COM5 ----
C:/DalFSAE/vehicle-control-unit/Core/Tests/hardware/hardware_test_runner.c:56:test_board_outputs_default_state:PASS
C:/DalFSAE/vehicle-control-unit/Core/Tests/hardware/hardware_test_runner.c:57:test_output_enable_disable:PASS
-----------------------
2 Tests 0 Failures 0 Ignored 
OK
[     510] INFO  APP    BOOT           a0=2 a1=0
C:/DalFSAE/vehicle-control-unit/Core/Tests/hardware/hardware_test_runner.c:64:test_brake_light_flash:PASS
C:/DalFSAE/vehicle-control-unit/Core/Tests/hardware/hardware_test_runner.c:65:test_debug_led_flash:PASS
[    3912] INFO  APP    TASK_CREATED   a0=3 a1=0
[    4661] INFO  APP    HEARTBEAT      a0=1000 a1=0
[    5661] INFO  APP    HEARTBEAT      a0=1000 a1=0
[    6661] INFO  APP    HEARTBEAT      a0=1000 a1=0
[    7661] INFO  APP    HEARTBEAT      a0=1000 a1=0
```