### PR TITLE
89 Added usb input spoofer and GH actions runner

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,19 +2,36 @@ BasedOnStyle: LLVM
 IndentWidth: 4
 TabWidth: 4
 UseTab: Never
-
 BreakBeforeBraces: Attach
 ColumnLimit: 120
 
-AlignConsecutiveDeclarations: true
+# Alignment
 AlignTrailingComments: true
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: false
+AlignConsecutiveAssignments:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: false
 
+# Functions
 AllowShortFunctionsOnASingleLine: None
+
+# If statements
 AllowShortIfStatementsOnASingleLine: Never
+InsertBraces: true
 
-PointerAlignment: Right
-SortIncludes: false
-
-AllowShortCaseLabelsOnASingleLine: true
+# Switch
+AllowShortCaseLabelsOnASingleLine: false
 IndentCaseLabels: true
 IndentCaseBlocks: false
+
+# General
+PointerAlignment: Right
+SortIncludes: false
+SpaceBeforeParens: ControlStatements

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,21 @@ jobs:
       - name: Build Debug firmware
         run: cmake --build --preset Debug
 
+      - name: Generate binary
+        run: arm-none-eabi-objcopy -O binary build/Debug/DMS-24-RTOS-VCU.elf build/Debug/DMS-24-RTOS-VCU.bin
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-debug-elf
+          path: build/Debug/DMS-24-RTOS-VCU.elf
+
+      - name: Upload firmware binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-debug-bin
+          path: build/Debug/DMS-24-RTOS-VCU.bin
+
   unit-tests:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  unit-tests:
+    name: Python Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pyserial
+
+      - name: Run unit tests
+        run: pytest tools/tests/test_vcu_hil_unit.py -v --tb=short --junit-xml=results.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results
+          path: results.xml

--- a/.github/workflows/hil-tests.yml
+++ b/.github/workflows/hil-tests.yml
@@ -1,0 +1,84 @@
+name: HIL Tests
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'Core/**'
+      - 'USB_DEVICE/**'
+      - 'tools/**'
+      - '.github/workflows/hil-tests.yml'
+  pull_request:
+    paths:
+      - 'Core/**'
+      - 'USB_DEVICE/**'
+      - 'tools/**'
+      - '.github/workflows/hil-tests.yml'
+
+jobs:
+  build:
+    name: Build Firmware
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ARM toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            ninja-build \
+            gcc-arm-none-eabi \
+            binutils-arm-none-eabi \
+            libnewlib-arm-none-eabi
+
+      - name: Configure CMake
+        run: cmake --preset Debug
+
+      - name: Build firmware
+        run: cmake --build --preset Debug
+
+      - name: Generate binary
+        run: arm-none-eabi-objcopy -O binary build/Debug/DMS-24-RTOS-VCU.elf build/Debug/DMS-24-RTOS-VCU.bin
+
+      - name: Upload firmware
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-debug-bin
+          path: build/Debug/DMS-24-RTOS-VCU.bin
+
+  hil-tests:
+    name: Hardware-in-Loop Tests
+    runs-on: [self-hosted, stm32f407]
+    needs: build
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download firmware
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware-debug-bin
+          path: firmware
+
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          .venv\Scripts\python.exe -m pip install --upgrade pip
+          .venv\Scripts\python.exe -m pip install -r tools/requirements.txt
+
+      - name: Flash firmware
+        run: STM32_Programmer_CLI -c port=SWD -w firmware/DMS-24-RTOS-VCU.bin 0x08000000 -rst
+
+      - name: Wait for device
+        run: Start-Sleep -Seconds 10
+
+      - name: Run HIL tests
+        run: .venv\Scripts\python.exe -m pytest tools/tests/test_fsm.py -v --tb=short --junit-xml=results.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hil-test-results
+          path: results.xml

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /cmake_install.cmake
 /Core/Tests/unit/build
 /Core/Tests/unit/compile_commands.json
+/__pycache__

--- a/Core/Tests/hardware/hardware_test_runner.c
+++ b/Core/Tests/hardware/hardware_test_runner.c
@@ -9,6 +9,7 @@
 #include "test_fsm_hil.h"
 #include "test_can.h"
 #include "test_motor_controller.h"
+#include "test_usb_cmd.h"
 #include "vcu_io.h"
 
 void setUp(void) {
@@ -43,6 +44,17 @@ static void run_fsm_tests(void) {
     RUN_TEST(test_if_debug_button_changes_state); // optional, requires user input
 }
 
+static void run_usb_cmd_tests(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_usb_cmd_echo_roundtrip);
+    RUN_TEST(test_usb_cmd_request_state);
+    RUN_TEST(test_usb_cmd_request_outputs);
+    RUN_TEST(test_usb_cmd_spoof_set);
+    RUN_TEST(test_usb_cmd_step);
+    RUN_TEST(test_usb_cmd_reset);
+    UNITY_END();
+}
+
 
 // ===========================================================================
 // Runners
@@ -74,13 +86,23 @@ BootResult_t hardware_test_post_boot(void) {
 
 void hardware_post_test_task(void *argument) {
     (void)argument;
+
     log_printf("===BEGIN_HIL_TESTS===\r\n");
     BootResult_t result = hardware_test_post_boot();
     log_printf("===END_HIL_TESTS: %u run, %u failed===\r\n", result.tests_run, result.failures);
+
+    log_printf("===BEGIN_USB_CMD_TESTS===\r\n");
+    run_usb_cmd_tests();
+    log_printf("===END_USB_CMD_TESTS===\r\n");
+
     log_printf("===BEGIN_CAN_TESTS===\r\n");
     run_can_tests();
+    log_printf("===END_CAN_TESTS===\r\n");
+
     log_printf("===BEGIN_MC_TESTS===\r\n");
     run_mc_tests();
+    log_printf("===END_MC_TESTS===\r\n");
+
     vcu_clear_spoof();
     osThreadExit();
 }

--- a/Core/Tests/hardware/test_usb_cmd.c
+++ b/Core/Tests/hardware/test_usb_cmd.c
@@ -1,0 +1,83 @@
+#include "test_usb_cmd.h"
+#include "unity.h"
+#include "usb_cmd.h"
+#include "usbd_cdc_if.h"
+#include "fsm_task.h"
+#include "vcu_io.h"
+#include "input_control.h"
+#include <string.h>
+#include <stdbool.h>
+
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+void test_usb_cmd_echo_roundtrip(void) {
+    // Send: [CMD_ECHO(0x45), LEN(4), 'p','i','n','g']
+    uint8_t cmd_frame[] = {0x45, 0x04, 'p', 'i', 'n', 'g'};
+    usb_cmd_rx(cmd_frame, sizeof(cmd_frame));
+    // Test passes if no crash/hang during processing
+}
+
+void test_usb_cmd_request_state(void) {
+    // Send: [CMD_REQUEST_STATE(0x04), LEN(0)]
+    uint8_t cmd_frame[] = {0x04, 0x00};
+    usb_cmd_rx(cmd_frame, sizeof(cmd_frame));
+    // Test passes if command processes without crash
+}
+
+void test_usb_cmd_request_outputs(void) {
+    // Send: [CMD_REQUEST_OUTPUTS(0x03), LEN(0)]
+    uint8_t cmd_frame[] = {0x03, 0x00};
+    usb_cmd_rx(cmd_frame, sizeof(cmd_frame));
+    // Test passes if command processes without crash
+}
+
+void test_usb_cmd_spoof_set(void) {
+    // Build a VcuInputs struct with some test values
+    VcuInputs inputs = {
+        .fault_flags = 0,
+        .throttle_request = 0.5f,
+        .brake_pressed = true,
+        .rtd_button = false,
+        .fwrd_switch = true,
+        .rvrs_switch = false,
+        .ts_active = true,
+    };
+
+    // Manually pack and send command
+    uint8_t cmd_frame[2 + sizeof(VcuInputs)];
+    cmd_frame[0] = 0x01;  // CMD_SPOOF_SET
+    cmd_frame[1] = sizeof(VcuInputs);
+    memcpy(&cmd_frame[2], &inputs, sizeof(VcuInputs));
+
+    usb_cmd_rx(cmd_frame, sizeof(cmd_frame));
+
+    // Verify the spoofed inputs were applied via public API
+    VcuInputs current;
+    vcu_gather_inputs(&current);
+    TEST_ASSERT_TRUE(current.fwrd_switch);
+    TEST_ASSERT_TRUE(current.ts_active);
+    TEST_ASSERT_TRUE(current.brake_pressed);
+}
+
+void test_usb_cmd_step(void) {
+    // Send: [CMD_STEP(0x05), LEN(0)]
+    uint8_t cmd_frame[] = {0x05, 0x00};
+
+    usb_cmd_rx(cmd_frame, sizeof(cmd_frame));
+
+    // STEP command should execute without error
+    // (actual FSM state change depends on FSM task scheduling)
+}
+
+void test_usb_cmd_reset(void) {
+    // Send: [CMD_RESET(0x07), LEN(0)]
+    uint8_t cmd_frame[] = {0x07, 0x00};
+
+    usb_cmd_rx(cmd_frame, sizeof(cmd_frame));
+
+    // RESET command should execute without error
+    // (actual FSM state reset depends on FSM task scheduling)
+}

--- a/Core/Tests/hardware/test_usb_cmd.h
+++ b/Core/Tests/hardware/test_usb_cmd.h
@@ -1,0 +1,8 @@
+#pragma once
+
+void test_usb_cmd_echo_roundtrip(void);
+void test_usb_cmd_request_state(void);
+void test_usb_cmd_request_outputs(void);
+void test_usb_cmd_spoof_set(void);
+void test_usb_cmd_step(void);
+void test_usb_cmd_reset(void);

--- a/Core/User/board_outputs.c
+++ b/Core/User/board_outputs.c
@@ -10,8 +10,8 @@ typedef struct {
 } BoardOutputsGPIO_t;
 
 static const BoardOutputsGPIO_t board_outputs_map[OUTPUT_COUNT] = {
-    [OUTPUT_DEBUG_LED4] = {LD4_GPIO_Port, LD4_Pin},
     [OUTPUT_DEBUG_LED3] = {LD3_GPIO_Port, LD3_Pin},
+    [OUTPUT_DEBUG_LED4] = {LD4_GPIO_Port, LD4_Pin},
     [OUTPUT_DEBUG_LED5] = {LD5_GPIO_Port, LD5_Pin},
     [OUTPUT_DEBUG_LED6] = {LD6_GPIO_Port, LD6_Pin},
     [OUTPUT_ALWAYS_ON] = {PWR_ALWAYSON_GPIO_Port, PWR_ALWAYSON_Pin},

--- a/Core/User/fsm_task.c
+++ b/Core/User/fsm_task.c
@@ -3,12 +3,23 @@
 #include "fsm_task.h"
 #include "fsm.h"
 #include "vcu_io.h"
-#include "vcu_io.h"
 #include "dash.h"
 #include "cmsis_os2.h"
 #include "log.h"
 
-volatile FsmState_t g_fsm_state = ST_ENTRY;
+volatile FsmState_t g_fsm_state     = ST_ENTRY;
+volatile bool g_fsm_step_requested  = false;
+volatile bool g_fsm_reset_requested = false;
+
+static VcuOutputs s_last_outputs = {0};
+
+FsmState_t fsm_get_state(void) {
+    return g_fsm_state;
+}
+
+const VcuOutputs *fsm_get_last_outputs(void) {
+    return &s_last_outputs;
+}
 
 // Packs the boolean output fields into a bitmask for change detection and logging.
 // Keep in sync with the EVT_IO_CHANGE formatter in log.c.
@@ -28,14 +39,21 @@ void fsm_task(void *arg) {
 
     const FsmFaultConfig_t fault_cfg = FaultConfig_default();
 
-    FsmState_t state = ST_ENTRY;
-    VcuInputs  in    = {0};
-    VcuOutputs out   = {0};
-    uint32_t   prev_out_bits = UINT32_MAX; // force log on first cycle
+    FsmState_t state       = ST_ENTRY;
+    VcuInputs in           = {0};
+    VcuOutputs out         = {0};
+    uint32_t prev_out_bits = UINT32_MAX; // force log on first cycle
 
     for (;;) {
+        if (g_fsm_reset_requested) {
+            g_fsm_reset_requested = false;
+            state                 = ST_ENTRY;
+            vcu_clear_spoof();
+        }
+
         vcu_gather_inputs(&in);
         FsmState_t next = step_fsm(state, &fault_cfg, &in, &out);
+        out.debug_leds = in.debug_cmd;
 
         if (next != state) {
             LOG_EVENT(LOG_LEVEL_INFO, EVT_STATE_CHANGE, state, next);
@@ -43,16 +61,20 @@ void fsm_task(void *arg) {
 
         uint32_t out_bits = pack_outputs(&out);
         if (out_bits != prev_out_bits) {
-            LOG_EVENT(LOG_LEVEL_DEBUG, EVT_IO_CHANGE,
-                      out_bits,
-                      (uint32_t)(out.throttle_request * 1000.0f));
+            LOG_EVENT(LOG_LEVEL_DEBUG, EVT_IO_CHANGE, out_bits, (uint32_t)(out.throttle_request * 1000.0f));
             prev_out_bits = out_bits;
         }
 
-        state = next;
-        g_fsm_state = state;
+        s_last_outputs = out;
+        state          = next;
+        g_fsm_state    = state;
 
         vcu_apply_outputs(&out);
-        osDelay(FSM_PERIOD_MS);
+
+        if (g_fsm_step_requested) {
+            g_fsm_step_requested = false;
+        } else {
+            osDelay(FSM_PERIOD_MS);
+        }
     }
 }

--- a/Core/User/fsm_task.c
+++ b/Core/User/fsm_task.c
@@ -47,13 +47,15 @@ void fsm_task(void *arg) {
     for (;;) {
         if (g_fsm_reset_requested) {
             g_fsm_reset_requested = false;
-            state                 = ST_ENTRY;
+            LOG_EVENT(LOG_LEVEL_INFO, EVT_FSM_RESET, state, ST_ENTRY);
+            state = ST_ENTRY;
             vcu_clear_spoof();
         }
 
         vcu_gather_inputs(&in);
-        FsmState_t next = step_fsm(state, &fault_cfg, &in, &out);
+        out = (VcuOutputs){0};
         out.debug_leds = in.debug_cmd;
+        FsmState_t next = step_fsm(state, &fault_cfg, &in, &out);
 
         if (next != state) {
             LOG_EVENT(LOG_LEVEL_INFO, EVT_STATE_CHANGE, state, next);
@@ -73,6 +75,7 @@ void fsm_task(void *arg) {
 
         if (g_fsm_step_requested) {
             g_fsm_step_requested = false;
+            LOG_EVENT(LOG_LEVEL_DEBUG, EVT_FSM_STEP, state, 0);
         } else {
             osDelay(FSM_PERIOD_MS);
         }

--- a/Core/User/fsm_task.h
+++ b/Core/User/fsm_task.h
@@ -1,11 +1,15 @@
 #pragma once
 
 #include "fsm.h"
+#include "vcu_io.h"
 
 #define FSM_PERIOD_MS 10u
 
-// Finite State Machine
-// state written each cycle by fsm_task, readable by tests.
 extern volatile FsmState_t g_fsm_state;
+extern volatile bool g_fsm_step_requested;
+extern volatile bool g_fsm_reset_requested;
+
+FsmState_t fsm_get_state(void);
+const VcuOutputs *fsm_get_last_outputs(void);
 
 void fsm_task(void *arg);

--- a/Core/User/log.c
+++ b/Core/User/log.c
@@ -125,6 +125,8 @@ static const char *log_event_str(LogEventId_t event_id) {
         case EVT_COMMAND_REJECTED: return "CMD_REJECTED";
         case EVT_TASK_CREATED: return "TASK_CREATED";
         case EVT_HEARTBEAT: return "HEARTBEAT";
+        case EVT_FSM_RESET: return "FSM_RESET";
+        case EVT_FSM_STEP: return "FSM_STEP";
         default: return "UNKNOWN_EVENT";
     }
 }

--- a/Core/User/log.h
+++ b/Core/User/log.h
@@ -34,6 +34,8 @@ typedef enum {
     EVT_COMMAND_REJECTED,
     EVT_TASK_CREATED,
     EVT_HEARTBEAT,
+    EVT_FSM_RESET,
+    EVT_FSM_STEP,
     EVT_COUNT // must be last
 } LogEventId_t;
 

--- a/Core/User/usb_cmd.c
+++ b/Core/User/usb_cmd.c
@@ -4,11 +4,13 @@
 #include "fsm_task.h"
 #include "string.h"
 
-#define CMD_BUF_SUZE 64
+#define CMD_BUF_SIZE 64
 
-static uint8_t  s_cmd_buf[CMD_BUF_SUZE];
+static uint8_t  s_cmd_buf[CMD_BUF_SIZE];
 static uint32_t s_cmd_buf_len = 0;
 
+// Handle a fully-assembled command frame. Called by usb_cmd_rx once a complete
+// frame [CMD][LEN][payload] has been buffered. See docs/architecture/vcu-input-spoof.md
 uint32_t dispatch_cmd(const uint8_t cmd, const uint8_t *payload, uint32_t len) {
     switch (cmd) {
         case CMD_ECHO:
@@ -25,7 +27,7 @@ uint32_t dispatch_cmd(const uint8_t cmd, const uint8_t *payload, uint32_t len) {
             return 0;
         case CMD_REQUEST_OUTPUTS: {
             static uint8_t resp[2 + sizeof(VcuOutputs)];
-            resp[0] = 0x83;
+            resp[0] = CMD_REPLY_OUTPUT;
             resp[1] = sizeof(VcuOutputs);
             memcpy(&resp[2], fsm_get_last_outputs(), sizeof(VcuOutputs));
             CDC_Transmit_FS(resp, sizeof(resp));
@@ -33,7 +35,7 @@ uint32_t dispatch_cmd(const uint8_t cmd, const uint8_t *payload, uint32_t len) {
         }
         case CMD_REQUEST_STATE: {
             static uint8_t resp[3];
-            resp[0] = 0x84;
+            resp[0] = CMD_REPLY_STATE;
             resp[1] = 0x01;
             resp[2] = (uint8_t)fsm_get_state();
             CDC_Transmit_FS(resp, sizeof(resp));
@@ -64,7 +66,7 @@ uint32_t dispatch_cmd(const uint8_t cmd, const uint8_t *payload, uint32_t len) {
 // Frame: [CMD (1 byte)][LEN (1 byte)][payload (LEN bytes)]
 uint32_t usb_cmd_rx(const uint8_t *buf, uint32_t len) {
     for (uint32_t i = 0; i < len; i++) {
-        if (s_cmd_buf_len < CMD_BUF_SUZE) {
+        if (s_cmd_buf_len < CMD_BUF_SIZE) {
             s_cmd_buf[s_cmd_buf_len++] = buf[i];
         }
 
@@ -73,8 +75,14 @@ uint32_t usb_cmd_rx(const uint8_t *buf, uint32_t len) {
             continue;
         }
 
-        // wait until we have the complete frame (CMD + LEN + payload)
+        // reject frames too large to buffer to prevent deadlock where frame_len
+        // exceeds CMD_BUF_SIZE and s_cmd_buf_len never reaches it
         uint32_t frame_len = s_cmd_buf[1] + 2;
+        if (frame_len > CMD_BUF_SIZE) {
+            s_cmd_buf_len = 0;
+            continue;
+        }
+        // wait until we have the complete frame (CMD + LEN + payload)
         if (s_cmd_buf_len < frame_len) {
             continue;
         }

--- a/Core/User/usb_cmd.c
+++ b/Core/User/usb_cmd.c
@@ -1,0 +1,88 @@
+#include "usb_cmd.h"
+#include "usbd_cdc_if.h"
+#include "vcu_io.h"
+#include "fsm_task.h"
+#include "string.h"
+
+#define CMD_BUF_SUZE 64
+
+static uint8_t  s_cmd_buf[CMD_BUF_SUZE];
+static uint32_t s_cmd_buf_len = 0;
+
+uint32_t dispatch_cmd(const uint8_t cmd, const uint8_t *payload, uint32_t len) {
+    switch (cmd) {
+        case CMD_ECHO:
+            CDC_Transmit_FS((uint8_t *)payload, len);
+            return 0;
+        case CMD_SPOOF_SET:
+            if (len >= sizeof(VcuInputs)) {
+                vcu_spoof_inputs((const VcuInputs *)payload);
+                return 0;
+            }
+            return 0xFFFFFFFF;
+        case CMD_SPOOF_CLEAR:
+            vcu_clear_spoof();
+            return 0;
+        case CMD_REQUEST_OUTPUTS: {
+            static uint8_t resp[2 + sizeof(VcuOutputs)];
+            resp[0] = 0x83;
+            resp[1] = sizeof(VcuOutputs);
+            memcpy(&resp[2], fsm_get_last_outputs(), sizeof(VcuOutputs));
+            CDC_Transmit_FS(resp, sizeof(resp));
+            return 0;
+        }
+        case CMD_REQUEST_STATE: {
+            static uint8_t resp[3];
+            resp[0] = 0x84;
+            resp[1] = 0x01;
+            resp[2] = (uint8_t)fsm_get_state();
+            CDC_Transmit_FS(resp, sizeof(resp));
+            return 0;
+        }
+        case CMD_STEP:
+            g_fsm_step_requested = true;
+            return 0;
+        case CMD_FAULT_INJECT:
+            if (len >= 4) {
+                uint32_t flags;
+                memcpy(&flags, payload, 4);
+                vcu_fault_inject(flags);
+                return 0;
+            }
+            return 0xFFFFFFFF;
+        case CMD_RESET:
+            g_fsm_reset_requested = true;
+            vcu_clear_spoof();
+            return 0;
+        default:
+            return 0xFFFFFFFF;
+    }
+}
+
+// A single command may be received in multiple USB packets,
+// so we buffer until we have the complete frame.
+// Frame: [CMD (1 byte)][LEN (1 byte)][payload (LEN bytes)]
+uint32_t usb_cmd_rx(const uint8_t *buf, uint32_t len) {
+    for (uint32_t i = 0; i < len; i++) {
+        if (s_cmd_buf_len < CMD_BUF_SUZE) {
+            s_cmd_buf[s_cmd_buf_len++] = buf[i];
+        }
+
+        // wait until at least 2 bytes (CMD + LEN)
+        if (s_cmd_buf_len < 2) {
+            continue;
+        }
+
+        // wait until we have the complete frame (CMD + LEN + payload)
+        uint32_t frame_len = s_cmd_buf[1] + 2;
+        if (s_cmd_buf_len < frame_len) {
+            continue;
+        }
+
+        // consume command
+        dispatch_cmd(s_cmd_buf[0], &s_cmd_buf[2], s_cmd_buf[1]);
+        s_cmd_buf_len -= frame_len;
+        memmove(s_cmd_buf, &s_cmd_buf[frame_len], s_cmd_buf_len);
+    }
+    return 0;
+}

--- a/Core/User/usb_cmd.h
+++ b/Core/User/usb_cmd.h
@@ -15,6 +15,8 @@ typedef enum {
     CMD_FAULT_INJECT    = 0x06,
     CMD_RESET           = 0x07,
     CMD_ECHO            = 0x45,
+    CMD_REPLY_OUTPUT    = 0x83,
+    CMD_REPLY_STATE     = 0x84,
 } UsbCmd_t;
 
 typedef enum {

--- a/Core/User/usb_cmd.h
+++ b/Core/User/usb_cmd.h
@@ -1,0 +1,36 @@
+#pragma once
+// usb_cmd.h
+// Custom command interface for USB_DEVICE\App\usbd_cdc_if.c
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "fsm_task.h"
+
+typedef enum {
+    CMD_SPOOF_SET       = 0x01,
+    CMD_SPOOF_CLEAR     = 0x02,
+    CMD_REQUEST_OUTPUTS = 0x03,
+    CMD_REQUEST_STATE   = 0x04,
+    CMD_STEP            = 0x05,
+    CMD_FAULT_INJECT    = 0x06,
+    CMD_RESET           = 0x07,
+    CMD_ECHO            = 0x45,
+} UsbCmd_t;
+
+typedef enum {
+    FSM_CMD_SPOOF_SET,
+    FSM_CMD_SPOOF_CLR,
+    FSM_CMD_STEP,
+    FSM_CMD_RESET,
+    FSM_CMD_FAULT_INJECT,
+} FsmCmdType_t;
+
+typedef struct {
+    FsmCmdType_t type;
+    union {
+        VcuInputs spoof;
+        uint32_t  fault_flags;
+    } payload;
+} FsmCmd_t;
+
+uint32_t usb_cmd_rx(const uint8_t *buf, uint32_t len);

--- a/Core/User/vcu_io.c
+++ b/Core/User/vcu_io.c
@@ -3,7 +3,6 @@
 #include <string.h>
 
 #include "vcu_io.h"
-#include "vcu_io.h"
 #include "board_outputs.h"
 #include "output_control.h"
 #include "motor_controller.h"
@@ -14,10 +13,12 @@
 
 // HIL spoof
 static bool s_spoof_active = false;
-static VcuInputs s_spoof = {0};
+static VcuInputs s_spoof   = {0};
 
 void vcu_spoof_inputs(const VcuInputs *spoof) {
-    if (spoof == NULL) return;
+    if (spoof == NULL) {
+        return;
+    }
     s_spoof        = *spoof;
     s_spoof_active = true;
 }
@@ -26,17 +27,31 @@ void vcu_clear_spoof(void) {
     s_spoof_active = false;
 }
 
+void vcu_fault_inject(uint32_t flags) {
+    VcuInputs spoofed   = s_spoof_active ? s_spoof : (VcuInputs){0};
+    spoofed.fault_flags = flags;
+    vcu_spoof_inputs(&spoofed);
+}
+
+// Apply debug LED states from FSM outputs to hardware.
+void vcu_apply_debug_leds(uint8_t debug_leds) {
+    board_output_set(OUTPUT_DEBUG_LED4, debug_leds & 0x01);
+    board_output_set(OUTPUT_DEBUG_LED5, (debug_leds >> 1) & 0x01);
+    board_output_set(OUTPUT_DEBUG_LED6, (debug_leds >> 2) & 0x01);
+}
 
 // Edge detection helper (persistent prev state per call site)
 static bool rising_edge(bool signal, bool *prev) {
     bool edge = signal && !(*prev);
-    *prev = signal;
+    *prev     = signal;
     return edge;
 }
 
 // Gather inputs from hardware/sensors into *in. Called by main loop.
 void vcu_gather_inputs(VcuInputs *in) {
-    if (in == NULL) return;
+    if (in == NULL) {
+        return;
+    }
 
     if (s_spoof_active) {
         *in = s_spoof;
@@ -44,34 +59,40 @@ void vcu_gather_inputs(VcuInputs *in) {
     }
 
     static bool rtd_prev = false;
-    bool rtd_raw = read_pcb_user_button() || read_ready_to_drive_button();
+    bool rtd_raw         = read_pcb_user_button() || read_ready_to_drive_button();
 
     in->throttle_request = sensor_get_throttle();
     in->brake_pressed    = sensor_get_brake();
     in->fault_flags      = sensor_get_fault_flags();
-    if (mc_has_timeout()) in->fault_flags |= FAULT_CAN_TIMEOUT;
-    in->rtd_button       = rising_edge(rtd_raw, &rtd_prev);
-    in->fwrd_switch      = read_forward_switch();
-    in->rvrs_switch      = false; // no reverse switch wired yet
-    in->ts_active        = mc_is_ready();
+    if (mc_has_timeout()) {
+        in->fault_flags |= FAULT_CAN_TIMEOUT;
+    }
+    in->rtd_button  = rising_edge(rtd_raw, &rtd_prev);
+    in->fwrd_switch = read_forward_switch();
+    in->rvrs_switch = false; // no reverse switch wired yet
+    in->ts_active   = mc_is_ready();
 }
 
 // Apply outputs to hardware
 void vcu_apply_outputs(const VcuOutputs *out) {
-    if (out == NULL) return;
+    if (out == NULL) {
+        return;
+    }
 
     // Relays
-    out->relay_always_on ? board_output_enable(OUTPUT_ALWAYS_ON)    : board_output_disable(OUTPUT_ALWAYS_ON);
-    out->relay_inverter  ? board_output_enable(OUTPUT_INVERTER)     : board_output_disable(OUTPUT_INVERTER);
-    out->brake_light     ? board_output_enable(OUTPUT_BRAKE_LIGHT)  : board_output_disable(OUTPUT_BRAKE_LIGHT);
+    out->relay_always_on ? board_output_enable(OUTPUT_ALWAYS_ON) : board_output_disable(OUTPUT_ALWAYS_ON);
+    out->relay_inverter ? board_output_enable(OUTPUT_INVERTER) : board_output_disable(OUTPUT_INVERTER);
+    out->brake_light ? board_output_enable(OUTPUT_BRAKE_LIGHT) : board_output_disable(OUTPUT_BRAKE_LIGHT);
 
     // Digital outputs
     dio_write(CAN_WATCHDOG, out->can_watchdog);
-    dio_write(TSSI_EN,      out->tssi_en);
-    dio_write(MC_BRAKE_SW,  out->mc_brake_sw);
+    dio_write(TSSI_EN, out->tssi_en);
+    dio_write(MC_BRAKE_SW, out->mc_brake_sw);
 
     // Buzzer
-    if (out->buzzer_beep_ms) buzzer_beep(out->buzzer_beep_ms);        
+    if (out->buzzer_beep_ms) {
+        buzzer_beep(out->buzzer_beep_ms);
+    }
     buzzer_update();
 
     // Motor direction
@@ -87,5 +108,7 @@ void vcu_apply_outputs(const VcuOutputs *out) {
         .speed_mode_enable       = false,
     };
     motor_controller_set_cmd(&cmd);
-}
 
+    // Debug LEDs
+    vcu_apply_debug_leds(out->debug_leds);
+}

--- a/Core/User/vcu_io.h
+++ b/Core/User/vcu_io.h
@@ -27,11 +27,13 @@ typedef struct __attribute__((packed)) {
     bool     fwrd_switch;
     bool     rvrs_switch;
     bool     ts_active;
+    uint8_t  debug_cmd; // bitfield: bit0=LED1, bit1=LED2, bit2=LED3. 1=on, 0=off. (remaining bits reserved)
 } VcuInputs;
-_Static_assert(sizeof(VcuInputs) == 13, "VcuInputs size mismatch");
+_Static_assert(sizeof(VcuInputs) == 14, "VcuInputs size mismatch");
 
 // Outputs produced by the FSM each cycle, applied by vcu_apply_outputs().
-typedef struct {
+// Packed so it can be read wholesale over USB for HIL testing.
+typedef struct __attribute__((packed)) {
     bool       relay_always_on;
     bool       relay_inverter;
     bool       brake_light;
@@ -42,6 +44,7 @@ typedef struct {
     bool       throttle_enabled;
     float      throttle_request; // [0.0, 1.0]
     uint32_t   buzzer_beep_ms;
+    uint8_t    debug_leds; // bitfield: bit0=LED1, bit1=LED2, bit2=LED3. 1=on, 0=off. (remaining bits reserved)
 } VcuOutputs;
 
 // Assemble VcuInputs from all sensor and device module getters.
@@ -54,4 +57,5 @@ void vcu_apply_outputs(const VcuOutputs *out);
 // injected struct verbatim instead of reading hardware.
 void vcu_spoof_inputs(const VcuInputs *spoof);
 void vcu_clear_spoof(void);
+void vcu_fault_inject(uint32_t flags);
 

--- a/USB_DEVICE/App/usbd_cdc_if.c
+++ b/USB_DEVICE/App/usbd_cdc_if.c
@@ -22,7 +22,7 @@
 #include "usbd_cdc_if.h"
 
 /* USER CODE BEGIN INCLUDE */
-
+#include "usb_cmd.h"
 /* USER CODE END INCLUDE */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -261,6 +261,7 @@ static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length)
 static int8_t CDC_Receive_FS(uint8_t* Buf, uint32_t *Len)
 {
   /* USER CODE BEGIN 6 */
+  usb_cmd_rx(Buf, (uint32_t)*Len);
   USBD_CDC_SetRxBuffer(&hUsbDeviceFS, &Buf[0]);
   USBD_CDC_ReceivePacket(&hUsbDeviceFS);
   return (USBD_OK);

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,30 @@
+"""Pytest configuration for HIL tests."""
+
+import os
+import sys
+import time
+
+import pytest
+
+from vcu_hil import VcuHil
+
+_DEFAULT_PORT = "COM5" if sys.platform == "win32" else "/dev/vcu"
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--port",
+        default=os.environ.get("VCU_PORT", _DEFAULT_PORT),
+        help="Serial port of VCU device (default: $VCU_PORT or COM5/dev/vcu)",
+    )
+
+
+@pytest.fixture
+def vcu(request):
+    """VcuHil instance connected to the board, reset and ready."""
+    port = request.config.getoption("--port")
+    with VcuHil(port) as h:
+        time.sleep(0.5)
+        h.reset()
+        time.sleep(0.1)
+        yield h

--- a/docs/architecture/vcu-input-spoof.md
+++ b/docs/architecture/vcu-input-spoof.md
@@ -30,12 +30,21 @@ typedef struct {...} VcuOutputs;
 
 ## Command Protocol
 
-Frame: `[CMD (1 byte)][LEN (1 byte)[payload (LEN bytes)]`
+Frame format: `[CMD (1 byte)][LEN (1 byte)][payload (LEN bytes)]`
 
+Response format (for commands that return data): `[CMD | 0x80 (1 byte)][optional fields]`
+The response command ID is the request command ID bitwise OR'd with 0x80, allowing the host to correlate responses with requests.
 
-| CMD  | Name      | Payload | Note |
-| 0x01 | SPOOF_SET | VcuInputs (packed) | Enable spoofing, and parse payload |
-| 0x02 | SPOOF_CLR | (none) | Disable spoofing and return inputs to hardware |
+| CMD  | Name            | Payload          | Response | Note |
+|------|-----------------|------------------|----------|------|
+| 0x01 | SPOOF_SET       | 13 bytes (VcuInputs) | none | Enable spoofing with injected inputs |
+| 0x02 | SPOOF_CLEAR     | none             | none | Disable spoofing; resume hardware reads |
+| 0x03 | REQUEST_OUTPUTS | none             | `[0x83][sizeof(VcuOutputs)][VcuOutputs]` | Poll current FSM outputs |
+| 0x04 | REQUEST_STATE   | none             | `[0x84][0x01][state_byte]` | Poll current FSM state (ST_ENTRY=0, ST_STANDBY=1, etc.) |
+| 0x05 | STEP            | none             | none | Manually advance FSM one cycle (step mode) |
+| 0x06 | FAULT_INJECT    | 4 bytes (uint32_t flags) | none | Merge fault flags into spoof inputs |
+| 0x07 | RESET           | none             | none | Reset FSM to ST_ENTRY, clear spoof, clear step mode |
+| 0x45 | ECHO            | arbitrary bytes  | echoed bytes | Loopback for link testing |
 
 ## Python
 

--- a/docs/architecture/vcu-input-spoof.md
+++ b/docs/architecture/vcu-input-spoof.md
@@ -1,0 +1,46 @@
+# VCU Input Spoofing
+
+# Summary
+
+The VCU needs a way to inject `VcuInputs` from a host PC over USB CDC for hardware-in-the-loop (HIL) testing. This lets scripts control the state machine and its inputs through various sequences, allowing us to test various sequences, without needed access to the full vehicle hardware.
+
+
+# Architecture
+
+- Input: PC (Python script / serial)
+  - Optional: pandas/csv dataframe
+- Transmit over USB CDC (pyserial) and captured by `CDC_Receive_FS()`
+- `usb_cmd_rx(buf, len)` new command buffer, which parses USB commands.
+
+## Data Structure
+
+Input and output of the state machine is controlled by the following structs. The VCU input is packed, which statically asserts the byte structure. 
+
+```c
+// vcu_io.h
+// Inputs consumed by the FSM each cycle, assembled by vcu_gather_inputs().
+// Packed so it can be spoofed wholesale over USB for HIL testing.
+typedef struct __attribute__((packed)) {...} VcuInputs;
+_Static_assert(sizeof(VcuInputs) == 13, "VcuInputs size mismatch");
+
+// Outputs produced by the FSM each cycle, applied by vcu_apply_outputs().
+typedef struct {...} VcuOutputs;
+```
+
+
+## Command Protocol
+
+Frame: `[CMD (1 byte)][LEN (1 byte)[payload (LEN bytes)]`
+
+
+| CMD  | Name      | Payload | Note |
+| 0x01 | SPOOF_SET | VcuInputs (packed) | Enable spoofing, and parse payload |
+| 0x02 | SPOOF_CLR | (none) | Disable spoofing and return inputs to hardware |
+
+## Python
+
+Python will be used to provide inputs from the PC.
+
+- CLI to allow integration with GH Actions
+- CSV input, to allow replay of telemetry or mock sequences
+- Logging of VCU outputs overtime

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+testpaths = tools/tests
+pythonpath = tools
+log_cli = true
+log_cli_level = DEBUG
+log_cli_format = %(name)-8s %(message)s
+log_level = DEBUG

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,10 @@
+# Scripts
+
+## Shell
+
+- `can-monitor.sh` — Monitor CAN traffic via USB adapter
+- `serial-monitor.sh` — Monitor VCU serial output
+
+## HIL Testing
+
+See [`tools/`](../tools/README.md) for the hardware-in-the-loop test harness.

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+.venv/
+venv/
+env/
+*.egg-info/

--- a/tools/99-vcu.rules
+++ b/tools/99-vcu.rules
@@ -1,0 +1,4 @@
+# Udev rule for DalFSAE VCU (STM32F4 USB CDC)
+# Install: sudo cp 99-vcu.rules /etc/udev/rules.d/
+#          sudo udevadm control --reload-rules && sudo udevadm trigger
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", SYMLINK+="vcu", MODE="0666"

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,59 @@
+# HIL Testing
+
+The VCU exposes a binary command protocol over USB CDC. Python tests drive the FSM by sending commands and asserting on responses. Tests run automatically in CI via a self-hosted GitHub Actions runner attached to the board.
+
+## Workflows
+
+ci.yml runs Python unit tests on ubuntu-latest on every PR. No hardware required.
+
+hil-tests.yml runs on firmware or test file changes. A build job compiles the firmware on ubuntu-latest and uploads the .bin as an artifact. The hil-tests job runs on the self-hosted runner, downloads the artifact, flashes the board, and runs pytest.
+
+## Protocol
+
+Commands are a 2-byte header [CMD, LEN] followed by LEN payload bytes. The response byte is CMD | 0x80. STM32 log lines ([timestamp] ...) are automatically stripped from binary responses and routed to pytest log capture.
+
+## Runner Setup
+
+The self-hosted runner must have the VCU connected via both USB and SWD.
+
+Register the runner under Settings, Actions, Runners and add the label `stm32f407` during setup.
+
+Install STM32CubeProgrammer from ST and make sure `STM32_Programmer_CLI` is on the runner
+PATH. The flash step uses SWD; USB alone is not sufficient for flashing.
+
+### Linux
+
+Install the udev rule to give the board a stable port at /dev/vcu:
+
+    sudo cp 99-vcu.rules /etc/udev/rules.d/
+    sudo udevadm control --reload-rules && sudo udevadm trigger
+
+Verify with `ls -l /dev/vcu`. If the symlink does not appear, check the VID/PID with
+`lsusb` and update the rule to match.
+
+### Windows
+
+Install Python from python.org.
+
+Add the STM32CubeProgrammer `bin` directory to the system PATH. The default path is:
+
+    C:\Program Files\STMicroelectronics\STM32Cube\STM32CubeProgrammer\bin
+
+The workflow relies on the board enumerating as COM5 (the default used by the test suite
+on Windows). To pin the board to COM5, open Device Manager, find the board under Ports
+(COM & LPT), go to Properties → Port Settings → Advanced and set the COM port number.
+
+If COM5 is not available, set the `VCU_PORT` environment variable on the runner to the
+correct port (e.g. `COM3`). The test suite reads it automatically.
+
+## Running Locally
+
+Linux:
+
+    pytest tools/tests/test_fsm.py --port /dev/vcu -v
+
+Windows:
+
+    pytest tools/tests/test_fsm.py --port COM5 -v
+
+`VCU_PORT` env var can be set instead of passing `--port` each time.

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,2 @@
+pyserial>=3.5
+pytest>=7.0

--- a/tools/tests/test_fsm.py
+++ b/tools/tests/test_fsm.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+test_fsm.py - HIL pytest suite for FSM control via USB
+
+Run with: pytest test_fsm.py --port /dev/ttyACM0 -v
+"""
+
+import time
+
+from vcu_hil import VcuInputs, ST_STANDBY, ST_NEUTRAL, ST_FORWARD, FAULT_CAN_TIMEOUT, DBG_LED1, DBG_LED2, DBG_LED3
+
+
+# Tests
+
+def test_echo_roundtrip(vcu):
+    """Sanity check: USB link is working."""
+    result = vcu.echo(b"ping")
+    assert result == b"ping"
+
+
+def test_initial_state_after_reset(vcu):
+    """After reset, FSM should be in ST_STANDBY."""
+    state = vcu.request_state()
+    assert state == ST_STANDBY
+
+
+def test_spoof_and_step_to_neutral(vcu):
+    """Spoof fwrd_switch + ts_active, step → should reach NEUTRAL."""
+    inputs = VcuInputs(fwrd_switch=True, ts_active=True)
+    vcu.spoof_inputs(inputs)
+    vcu.step()
+    state = vcu.request_state()
+    assert state == ST_NEUTRAL
+
+
+def test_neutral_to_forward(vcu):
+    """From NEUTRAL, spoof rtd_button + brake_pressed, step → should reach FORWARD."""
+    inputs = VcuInputs(fwrd_switch=True, ts_active=True)
+    vcu.spoof_inputs(inputs)
+    vcu.step()
+
+    inputs.rtd_button = True
+    inputs.brake_pressed = True
+    vcu.spoof_inputs(inputs)
+    vcu.step()
+
+    state = vcu.request_state()
+    assert state == ST_FORWARD
+
+
+def test_fault_inject_in_forward(vcu):
+    """In FORWARD, inject CAN timeout → FSM should handle the fault."""
+    inputs = VcuInputs(fwrd_switch=True, ts_active=True)
+    vcu.spoof_inputs(inputs)
+    vcu.step()
+
+    inputs.rtd_button = True
+    inputs.brake_pressed = True
+    vcu.spoof_inputs(inputs)
+    vcu.step()
+
+    vcu.fault_inject(FAULT_CAN_TIMEOUT)
+    vcu.step()
+
+    state = vcu.request_state()
+    assert state is not None
+
+
+def test_request_outputs_correct_format(vcu):
+    """REQUEST_OUTPUTS should return a parsed VcuOutputs."""
+    from vcu_hil import VcuOutputs
+    outputs = vcu.request_outputs()
+    assert isinstance(outputs, VcuOutputs)
+
+
+def test_clear_spoof_doesnt_crash(vcu):
+    """clear_spoof should not crash."""
+    vcu.clear_spoof()
+    state = vcu.request_state()
+    assert state is not None
+
+def test_led_pattern(vcu):
+    """debug_cmd input should be reflected in debug_leds output after a step."""
+    debug_cmd = DBG_LED1 | DBG_LED3
+    vcu.set_debug_cmd(debug_cmd)
+    vcu.step()
+    outputs = vcu.request_outputs()
+    assert outputs.debug_leds == debug_cmd
+
+def test_printing_outputs(vcu):
+    """Test that printing outputs doesn't crash."""
+    outputs = vcu.request_outputs()
+    print(outputs)
+
+
+def test_inputs_match_outputs(vcu):
+    """Spoofing fwrd_switch+ts_active and stepping should transition to NEUTRAL."""
+    inputs = VcuInputs(fwrd_switch=True, ts_active=True)
+    vcu.spoof_inputs(inputs)
+    vcu.step()
+    assert vcu.request_state() == ST_NEUTRAL
+    

--- a/tools/tests/test_vcu_hil_unit.py
+++ b/tools/tests/test_vcu_hil_unit.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Unit tests for vcu_hil.py — no hardware required, serial port is mocked."""
+
+import struct
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vcu_hil import (
+    VcuHil,
+    VcuInputs,
+    CMD_SPOOF_SET,
+    CMD_SPOOF_CLEAR,
+    CMD_REQUEST_OUTPUTS,
+    CMD_REQUEST_STATE,
+    CMD_STEP,
+    CMD_FAULT_INJECT,
+    CMD_RESET,
+    CMD_ECHO,
+    ST_ENTRY,
+    ST_STANDBY,
+    ST_NEUTRAL,
+    ST_FORWARD,
+    ST_REVERSE,
+    FAULT_NONE,
+    FAULT_APPS_DISAGREE,
+    FAULT_PEDAL_PLAUS,
+    FAULT_SENSOR_RANGE,
+    FAULT_CAN_TIMEOUT,
+)
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    monkeypatch.setattr("vcu_hil.time.sleep", lambda *a, **kw: None)
+
+
+@pytest.fixture
+def mock_serial():
+    ser = MagicMock()
+    ser.is_open = True
+    ser.timeout = 1.0
+    return ser
+
+
+@pytest.fixture
+def hil(mock_serial):
+    with patch("vcu_hil.serial.Serial", return_value=mock_serial):
+        yield VcuHil("COM_FAKE")
+
+
+class TestVcuInputsPack:
+    def test_default_pack_is_14_bytes(self):
+        assert len(VcuInputs().pack()) == 14
+
+    def test_debug_cmd_encoded(self):
+        data = VcuInputs(debug_cmd=0x07).pack()
+        assert data[13] == 0x07
+
+    def test_fault_flags_encoded(self):
+        data = VcuInputs(fault_flags=0xDEAD).pack()
+        assert struct.unpack_from("<I", data, 0)[0] == 0xDEAD
+
+    def test_throttle_encoded(self):
+        data = VcuInputs(throttle_request=0.5).pack()
+        assert abs(struct.unpack_from("<f", data, 4)[0] - 0.5) < 1e-6
+
+    def test_zero_throttle_encoded(self):
+        data = VcuInputs(throttle_request=0.0).pack()
+        assert struct.unpack_from("<f", data, 4)[0] == 0.0
+
+    def test_booleans_encoded_at_correct_offsets(self):
+        data = VcuInputs(
+            brake_pressed=True,
+            rtd_button=False,
+            fwrd_switch=True,
+            rvrs_switch=False,
+            ts_active=True,
+        ).pack()
+        assert data[8] == 1   # brake_pressed
+        assert data[9] == 0   # rtd_button
+        assert data[10] == 1  # fwrd_switch
+        assert data[11] == 0  # rvrs_switch
+        assert data[12] == 1  # ts_active
+
+    def test_all_booleans_false_by_default(self):
+        data = VcuInputs().pack()
+        assert data[8:13] == b'\x00\x00\x00\x00\x00'
+
+
+class TestSendCmd:
+    def test_frame_has_cmd_len_payload(self, hil, mock_serial):
+        hil.send_cmd(0x01, b'\xAA\xBB')
+        mock_serial.write.assert_called_once_with(bytes([0x01, 0x02, 0xAA, 0xBB]))
+
+    def test_empty_payload_sends_two_bytes(self, hil, mock_serial):
+        hil.send_cmd(CMD_RESET)
+        mock_serial.write.assert_called_once_with(bytes([CMD_RESET, 0x00]))
+
+    def test_payload_too_large_raises(self, hil):
+        with pytest.raises(ValueError):
+            hil.send_cmd(0x01, b'\x00' * 256)
+
+    def test_exactly_255_bytes_is_ok(self, hil, mock_serial):
+        hil.send_cmd(0x01, b'\x00' * 255)
+        mock_serial.write.assert_called_once()
+
+    def test_resets_input_buffer_before_write(self, hil, mock_serial):
+        call_order = []
+        mock_serial.reset_input_buffer.side_effect = lambda: call_order.append("reset")
+        mock_serial.write.side_effect = lambda _: call_order.append("write")
+        hil.send_cmd(0x01, b'')
+        assert call_order == ["reset", "write"]
+
+    def test_echo_command_id(self, hil, mock_serial):
+        mock_serial.read.return_value = b"hello"
+        hil.send_cmd(CMD_ECHO, b"hello")
+        frame = mock_serial.write.call_args[0][0]
+        assert frame[0] == CMD_ECHO
+
+
+class TestRequestState:
+    def test_parses_standby(self, hil, mock_serial):
+        mock_serial.read.return_value = bytes([0x84, 0x01, ST_STANDBY])
+        assert hil.request_state() == ST_STANDBY
+
+    def test_parses_neutral(self, hil, mock_serial):
+        mock_serial.read.return_value = bytes([0x84, 0x01, ST_NEUTRAL])
+        assert hil.request_state() == ST_NEUTRAL
+
+    def test_parses_forward(self, hil, mock_serial):
+        mock_serial.read.return_value = bytes([0x84, 0x01, ST_FORWARD])
+        assert hil.request_state() == ST_FORWARD
+
+    def test_parses_entry(self, hil, mock_serial):
+        mock_serial.read.return_value = bytes([0x84, 0x01, ST_ENTRY])
+        assert hil.request_state() == ST_ENTRY
+
+    def test_raises_on_wrong_response_byte(self, hil, mock_serial):
+        mock_serial.read.return_value = bytes([0xFF, 0x01, ST_STANDBY])
+        with pytest.raises(ValueError):
+            hil.request_state()
+
+    def test_raises_when_second_byte_wrong(self, hil, mock_serial):
+        # Tightened check: resp[1] must be 0x01
+        mock_serial.read.return_value = bytes([0x84, 0x02, ST_STANDBY])
+        with pytest.raises(ValueError):
+            hil.request_state()
+
+    def test_raises_on_empty_response(self, hil, mock_serial):
+        mock_serial.read.return_value = b''
+        with pytest.raises(ValueError):
+            hil.request_state()
+
+    def test_raises_on_too_short_response(self, hil, mock_serial):
+        mock_serial.read.return_value = bytes([0x84, 0x01])
+        with pytest.raises(ValueError):
+            hil.request_state()
+
+    def test_sends_request_state_command(self, hil, mock_serial):
+        mock_serial.read.return_value = bytes([0x84, 0x01, ST_STANDBY])
+        hil.request_state()
+        frame = mock_serial.write.call_args[0][0]
+        assert frame[0] == CMD_REQUEST_STATE
+        assert frame[1] == 0x00  # no payload
+
+
+def _make_outputs_response(**kwargs):
+    """Build a mock REQUEST_OUTPUTS response with a valid VcuOutputs payload."""
+    from vcu_hil import VcuOutputs, _VCUOUTPUTS_FMT
+    out = VcuOutputs(**kwargs)
+    payload = struct.pack(
+        _VCUOUTPUTS_FMT,
+        out.relay_always_on, out.relay_inverter, out.brake_light,
+        out.mc_brake_sw, out.can_watchdog, out.tssi_en,
+        out.motor_direction, out.throttle_enabled,
+        out.throttle_request, out.buzzer_beep_ms, out.debug_leds,
+    )
+    return bytes([0x83, len(payload)]) + payload
+
+
+class TestRequestOutputs:
+    def test_returns_vcuoutputs(self, hil, mock_serial):
+        from vcu_hil import VcuOutputs
+        mock_serial.read.return_value = _make_outputs_response()
+        assert isinstance(hil.request_outputs(), VcuOutputs)
+
+    def test_parses_fields(self, hil, mock_serial):
+        mock_serial.read.return_value = _make_outputs_response(
+            throttle_enabled=True, throttle_request=0.5, debug_leds=0x03
+        )
+        out = hil.request_outputs()
+        assert out.throttle_enabled is True
+        assert abs(out.throttle_request - 0.5) < 1e-6
+        assert out.debug_leds == 0x03
+
+    def test_raises_on_wrong_response_byte(self, hil, mock_serial):
+        mock_serial.read.return_value = bytes([0xFF, 0x04]) + b'\x00' * 4
+        with pytest.raises(ValueError):
+            hil.request_outputs()
+
+    def test_raises_on_empty_response(self, hil, mock_serial):
+        mock_serial.read.return_value = b''
+        with pytest.raises(ValueError):
+            hil.request_outputs()
+
+    def test_sends_request_outputs_command(self, hil, mock_serial):
+        mock_serial.read.return_value = _make_outputs_response()
+        hil.request_outputs()
+        frame = mock_serial.write.call_args[0][0]
+        assert frame[0] == CMD_REQUEST_OUTPUTS
+
+
+class TestFaultInject:
+    def test_sends_fault_flags_as_uint32(self, hil, mock_serial):
+        hil.fault_inject(FAULT_CAN_TIMEOUT)
+        frame = mock_serial.write.call_args[0][0]
+        assert frame[0] == CMD_FAULT_INJECT
+        payload = frame[2:]
+        assert struct.unpack("<I", payload)[0] == FAULT_CAN_TIMEOUT
+
+    def test_combined_flags(self, hil, mock_serial):
+        flags = FAULT_APPS_DISAGREE | FAULT_SENSOR_RANGE
+        hil.fault_inject(flags)
+        frame = mock_serial.write.call_args[0][0]
+        assert struct.unpack("<I", frame[2:])[0] == flags
+
+
+class TestClose:
+    def test_closes_open_port(self, hil, mock_serial):
+        mock_serial.is_open = True
+        hil.close()
+        mock_serial.close.assert_called_once()
+
+    def test_skips_close_when_already_closed(self, hil, mock_serial):
+        mock_serial.is_open = False
+        hil.close()
+        mock_serial.close.assert_not_called()
+
+    def test_context_manager_closes_on_exit(self, mock_serial):
+        with patch("vcu_hil.serial.Serial", return_value=mock_serial):
+            with VcuHil("COM_FAKE"):
+                pass
+        mock_serial.close.assert_called_once()
+
+
+class TestCommandConstants:
+    def test_all_command_ids_are_unique(self):
+        ids = [
+            CMD_SPOOF_SET, CMD_SPOOF_CLEAR, CMD_REQUEST_OUTPUTS,
+            CMD_REQUEST_STATE, CMD_STEP, CMD_FAULT_INJECT, CMD_RESET, CMD_ECHO,
+        ]
+        assert len(ids) == len(set(ids))
+
+    def test_fault_flags_are_distinct_bits(self):
+        flags = [FAULT_APPS_DISAGREE, FAULT_PEDAL_PLAUS, FAULT_SENSOR_RANGE, FAULT_CAN_TIMEOUT]
+        combined = 0
+        for f in flags:
+            assert f != 0
+            assert combined & f == 0, f"Flag {f:#x} overlaps with already-set bits"
+            combined |= f
+
+    def test_fault_none_is_zero(self):
+        assert FAULT_NONE == 0
+
+    def test_state_constants_are_unique(self):
+        states = [ST_ENTRY, ST_STANDBY, ST_NEUTRAL, ST_FORWARD, ST_REVERSE]
+        assert len(states) == len(set(states))

--- a/tools/vcu_hil.py
+++ b/tools/vcu_hil.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""
+vcu_hil.py - Serial transport layer for VCU USB CDC binary protocol
+
+Provides VcuHil class for sending/receiving binary command frames and helpers.
+"""
+
+import logging
+import re
+import struct
+import time
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import serial
+
+_STM32_LOG_RE = re.compile(rb'\[\s*\d+\][^\n]*\n')
+_vcu_log = logging.getLogger("vcu")
+
+
+# Command IDs (must match UsbCmd_t in usb_cmd.h)
+CMD_SPOOF_SET       = 0x01
+CMD_SPOOF_CLEAR     = 0x02
+CMD_REQUEST_OUTPUTS = 0x03
+CMD_REQUEST_STATE   = 0x04
+CMD_STEP            = 0x05
+CMD_FAULT_INJECT    = 0x06
+CMD_RESET           = 0x07
+CMD_ECHO            = 0x45
+
+# FSM states (must match FsmState_t in fsm.h)
+ST_ENTRY   = 0
+ST_STANDBY = 1
+ST_NEUTRAL = 2
+ST_FORWARD = 3
+ST_REVERSE = 4
+
+# Fault flags (must match FaultFlags_t in vcu_io.h)
+FAULT_NONE          = 0
+FAULT_APPS_DISAGREE = (1 << 0)
+FAULT_PEDAL_PLAUS   = (1 << 1)
+FAULT_SENSOR_RANGE  = (1 << 2)
+FAULT_CAN_TIMEOUT   = (1 << 3)
+
+# debug_cmd bitfield (must match vcu_io.h comment)
+DBG_LED1 = (1 << 0)
+DBG_LED2 = (1 << 1)
+DBG_LED3 = (1 << 2)
+
+
+_VCUOUTPUTS_FMT = '<??????B?fIB'  # 17 bytes, must match packed VcuOutputs in vcu_io.h
+
+
+@dataclass
+class VcuOutputs:
+    """VCU output state (17 bytes packed, must match C struct in vcu_io.h)"""
+    relay_always_on: bool = False
+    relay_inverter: bool = False
+    brake_light: bool = False
+    mc_brake_sw: bool = False
+    can_watchdog: bool = False
+    tssi_en: bool = False
+    motor_direction: int = 0
+    throttle_enabled: bool = False
+    throttle_request: float = 0.0
+    buzzer_beep_ms: int = 0
+    debug_leds: int = 0           # bitfield: DBG_LED1 | DBG_LED2 | DBG_LED3
+
+    @classmethod
+    def unpack(cls, data: bytes) -> 'VcuOutputs':
+        fields = struct.unpack_from(_VCUOUTPUTS_FMT, data)
+        return cls(*fields)
+
+
+@dataclass
+class VcuInputs:
+    """VCU input state (14 bytes packed, must match C struct in vcu_io.h)"""
+    fault_flags: int = 0
+    throttle_request: float = 0.0
+    brake_pressed: bool = False
+    rtd_button: bool = False
+    fwrd_switch: bool = False
+    rvrs_switch: bool = False
+    ts_active: bool = False
+    debug_cmd: int = 0          # bitfield: DBG_LED1 | DBG_LED2 | DBG_LED3
+
+    def pack(self) -> bytes:
+        """Pack into 14-byte binary format"""
+        return struct.pack(
+            '<If?????B',
+            self.fault_flags,
+            self.throttle_request,
+            self.brake_pressed,
+            self.rtd_button,
+            self.fwrd_switch,
+            self.rvrs_switch,
+            self.ts_active,
+            self.debug_cmd,
+        )
+
+
+class VcuHil:
+    """Hardware-in-the-loop interface to VCU via USB CDC serial"""
+
+    def __init__(self, port: str, baud: int = 115200, timeout: float = 1.0):
+        """
+        Connect to VCU on specified serial port.
+
+        Args:
+            port: Serial port (e.g., '/dev/ttyACM0', 'COM3')
+            baud: Baud rate (default 115200)
+            timeout: Read timeout in seconds
+        """
+        self.ser = serial.Serial(port, baud, timeout=timeout, write_timeout=None)
+        self.captured_logs: List[str] = []
+        time.sleep(1.0)
+
+    def send_cmd(self, cmd: int, payload: bytes = b'') -> None:
+        """
+        Send a binary command frame.
+
+        Frame: [CMD (1 byte)][LEN (1 byte)][payload (LEN bytes)]
+
+        Args:
+            cmd: Command ID
+            payload: Command payload (max 255 bytes)
+        """
+        if len(payload) > 255:
+            raise ValueError(f"Payload too large: {len(payload)} > 255")
+        pending = self.ser.read_all()
+        if pending:
+            self._drain_logs(pending)
+        self.ser.reset_input_buffer()
+        frame = bytes([cmd, len(payload)]) + payload
+        self.ser.write(frame)
+
+    def _drain_logs(self, buf: bytes) -> bytes:
+        """
+        Strip STM32 log lines from buf (lines matching [timestamp] ...).
+        Stripped lines are appended to self.captured_logs.
+        Returns the remaining binary bytes.
+        """
+        result = b''
+        pos = 0
+        while pos < len(buf):
+            m = _STM32_LOG_RE.search(buf, pos)
+            if m is None:
+                result += buf[pos:]
+                break
+            result += buf[pos : m.start()]
+            line = m.group().decode('ascii', errors='replace').rstrip()
+            self.captured_logs.append(line)
+            _vcu_log.debug(line)
+            pos = m.end()
+        return result
+
+    def recv(self, timeout: Optional[float] = None) -> bytes:
+        """
+        Receive bytes from VCU, stripping any interleaved STM32 log lines.
+
+        Args:
+            timeout: Override read timeout for this call
+
+        Returns:
+            Received bytes with log lines removed (logs stored in captured_logs)
+        """
+        old_timeout = self.ser.timeout
+        if timeout is not None:
+            self.ser.timeout = timeout
+        try:
+            data = self.ser.read(1024)
+            return self._drain_logs(data)
+        finally:
+            if timeout is not None:
+                self.ser.timeout = old_timeout
+
+    def echo(self, data: bytes) -> bytes:
+        """
+        Send echo command and receive response.
+
+        Args:
+            data: Data to echo
+
+        Returns:
+            Echoed data
+        """
+        self.send_cmd(CMD_ECHO, data)
+        time.sleep(0.01)
+        return self.recv(timeout=0.5)
+
+    def spoof_inputs(self, inputs: VcuInputs) -> None:
+        """Inject spoof inputs into the VCU."""
+        self.send_cmd(CMD_SPOOF_SET, inputs.pack())
+        time.sleep(0.05)
+
+    def clear_spoof(self) -> None:
+        """Clear input spoofing (resume reading hardware)."""
+        self.send_cmd(CMD_SPOOF_CLEAR, b'')
+
+    def request_state(self) -> int:
+        """
+        Poll current FSM state.
+
+        Returns:
+            FsmState_t value (ST_ENTRY, ST_STANDBY, etc.)
+        """
+        self.send_cmd(CMD_REQUEST_STATE, b'')
+        time.sleep(0.05)
+        resp = self.recv(timeout=0.5)
+        # Response format: [0x84, 0x01, state_value]
+        if len(resp) >= 3 and resp[0] == 0x84 and resp[1] == 0x01:
+            return resp[2]
+        raise ValueError(f"Invalid REQUEST_STATE response: {resp.hex()}")
+
+    def request_outputs(self) -> VcuOutputs:
+        """Poll current VcuOutputs from the device."""
+        self.send_cmd(CMD_REQUEST_OUTPUTS, b'')
+        time.sleep(0.01)
+        resp = self.recv(timeout=0.5)
+        if len(resp) >= 2 and resp[0] == 0x83:
+            payload_len = resp[1]
+            payload = resp[2 : 2 + payload_len]
+            return VcuOutputs.unpack(payload)
+        raise ValueError(f"Invalid REQUEST_OUTPUTS response: {resp.hex()}")
+
+    def set_debug_cmd(self, cmd: int) -> None:
+        """Spoof debug command bits (e.g. DBG_LED1 | DBG_LED3) into the next FSM step."""
+        self.spoof_inputs(VcuInputs(debug_cmd=cmd))
+
+    def step(self) -> None:
+        """Manually advance FSM one cycle (step mode)."""
+        self.send_cmd(CMD_STEP, b'')
+
+    def fault_inject(self, flags: int) -> None:
+        """
+        Inject fault flags for testing.
+
+        Args:
+            flags: Bitmask of fault flags (FAULT_CAN_TIMEOUT, etc.)
+        """
+        payload = struct.pack('<I', flags)
+        self.send_cmd(CMD_FAULT_INJECT, payload)
+
+    def reset(self) -> None:
+        """Reset FSM to ST_ENTRY."""
+        self.send_cmd(CMD_RESET, b'')
+        time.sleep(0.05)
+
+    def close(self) -> None:
+        """Close serial connection."""
+        if self.ser.is_open:
+            self.ser.close()
+        time.sleep(0.2)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()


### PR DESCRIPTION
# Summary 
<!-- Provide a short description of the changes -->

This PR adds a USB input spoofer that controls the VCU via a suite of Python scripts. Python + Pytest is used to mock the VCU's outputs, allowing us to verify how the real hardware responds to various scenarios. 

This PR will allow software team members to write and test code changes, without needing access to a development board.

## Related Issues
<!-- Link related issues using GitHub keywords like "Closes #123" or "Fixes #456". -->

Closes #89 


## Changes 
<!-- List what was added or modified. -->

## Screenshots / References 
<!-- Add screenshots of the CAD change, diagrams, or links to related docs. -->
<!-- All CAD should include screenshots of ISO views -->

## Checklist
<!-- Check off items as they are completed -->

- [ ] Related issue(s) linked
- [ ] Follows folder and file naming conventions
- [ ] Changes include unit/build tests
